### PR TITLE
mainDomain

### DIFF
--- a/src/config-node/index.ts
+++ b/src/config-node/index.ts
@@ -39,6 +39,11 @@ export function addProvider(provider: ConfigProvider) {
   configProviders.sort(compareProviders);
 }
 
+export function clearCache() {
+  configProviders.forEach(configProvider => configProvider.cache.clear());
+  commonCache.clear();
+}
+
 addProvider({
   description: "From ~/.config-node-devtools.json",
   priority: 11000,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,16 @@
 import {dxpConfig, initConfig} from './lxc-config';
 import {lookupConfig} from './config-node';
 
-const mainDomain = dxpConfig['com.liferay.lxc.dxp.mainDomain']();
-console.log('mainDomain', mainDomain);
+const dxpMainDomain = dxpConfig['com.liferay.lxc.dxp.main.domain']();
+console.log('dxpMainDomain', dxpMainDomain);
 
 const application1 = initConfig.get('lxc-config-json-1');
 
 if (application1) {
-  const headlessServerClientId = application1['oauth2.headless.server.client.id']();
-  console.log('headlessServerClientId', headlessServerClientId);
+  const outhUserAgentScopes = application1['oauth2.user.agent.scopes']();
+  console.log('outhUserAgentScopes ', outhUserAgentScopes);
+  const outhHeadlessServerClientId = application1['oauth2.headless.server.client.id']();
+  console.log('outhHeadlessServerClientId ', outhHeadlessServerClientId);
 }
 
 const customConfig = lookupConfig('custom.configuration');

--- a/src/lxc-config/index.ts
+++ b/src/lxc-config/index.ts
@@ -3,7 +3,8 @@ import {lookupConfig} from '../config-node';
 // type definitions
 type ConfigValueFunctionType = () => string | string[] | undefined;
 
-export type DXPConfigKey = 'com.liferay.lxc.dxp.domains' | 'com.liferay.lxc.dxp.mainDomain' | 'com.liferay.lxc.dxp.server.protocol';
+export type DXPConfigKey = 'com.liferay.lxc.dxp.domains' | 'com.liferay.lxc.dxp.main.domain' | 'com.liferay.lxc.dxp.mainDomain' |
+  'com.liferay.lxc.dxp.server.protocol';
 export type InitConfigKey = 'oauth2.authorization.uri' | 'oauth2.headless.server.audience' | 'oauth2.headless.server.client.id' |
   'oauth2.headless.server.client.secret' | 'oauth2.headless.server.scopes' | 'oauth2.introspection.uri' | 'oauth2.jwks.uri' |
   'oauth2.token.uri' | 'oauth2.user.agent.audience' | 'oauth2.user.agent.client.id' | 'oauth2.user.agent.scopes';
@@ -13,6 +14,7 @@ export type InitConfigType = Record<InitConfigKey, ConfigValueFunctionType>;
 
 export const dxpConfig: DXPConfigType = {
   'com.liferay.lxc.dxp.domains': () => lookupConfig('com.liferay.lxc.dxp.domains'),
+  'com.liferay.lxc.dxp.main.domain': () => lookupConfig('com.liferay.lxc.dxp.main.domain'),
   'com.liferay.lxc.dxp.mainDomain': () => lookupConfig('com.liferay.lxc.dxp.mainDomain'),
   'com.liferay.lxc.dxp.server.protocol': () => lookupConfig('com.liferay.lxc.dxp.server.protocol'),
 };

--- a/test/config-node.ts
+++ b/test/config-node.ts
@@ -1,4 +1,4 @@
-import {lookupConfig, defaultConfig, addProvider, ConfigProvider} from '../src/config-node';
+import {addProvider, clearCache, ConfigProvider, defaultConfig, lookupConfig} from '../src/config-node';
 import {assert} from 'chai';
 import sinon from 'sinon';
 import fs from 'fs';
@@ -24,6 +24,7 @@ describe('lookupConfig', function () {
     process.env.COM_LIFERAY_LXC_DXP_MAINDOMAIN = com_liferay_lxc_dxp_maindomain_env;
     process.argv = initial_argv;
     sinon.restore();
+    clearCache();
   });
 
   it('should return undefined when not present', function () {

--- a/test/lxc-config.ts
+++ b/test/lxc-config.ts
@@ -1,0 +1,32 @@
+import {dxpConfig, initConfig} from '../src/lxc-config';
+import {assert} from 'chai';
+
+describe('lxcConfig', function () {
+  it('should return main domain from both mainDomain or main.domain is specified', function () {
+    process.env.COM_LIFERAY_LXC_DXP_MAIN_DOMAIN = 'localhost:8080';
+    process.env.COM_LIFERAY_LXC_DXP_MAINDOMAIN = 'localhost:8080';
+    
+    assert.equal(
+      dxpConfig['com.liferay.lxc.dxp.main.domain'](),
+      'localhost:8080'
+    );
+
+    assert.equal(
+      dxpConfig['com.liferay.lxc.dxp.mainDomain'](),
+      'localhost:8080'
+    );
+  });
+
+  it('should handle ERCs that just have a single item', function () {
+    process.env.LIFERAY_OAUTH_APPLICATION_EXTERNAL_REFERENCE_CODES = 'foo'
+    
+    assert.isNotNull(initConfig['foo'])
+  });
+
+  it('should handle ERCs that have common delimited id list', function () {
+    process.env.LIFERAY_OAUTH_APPLICATION_EXTERNAL_REFERENCE_CODES = 'foo,bar'
+    
+    assert.isNotNull(initConfig['foo'])
+    assert.isNotNull(initConfig['bar'])
+  });
+});

--- a/test/lxc-config.ts
+++ b/test/lxc-config.ts
@@ -1,18 +1,36 @@
 import {dxpConfig, initConfig} from '../src/lxc-config';
+import {clearCache} from '../src/config-node';
 import {assert} from 'chai';
 
 describe('lxcConfig', function () {
+  let com_liferay_lxc_dxp_maindomain_env;
+  let com_liferay_lxc_dxp_main_domain_env;
+  let liferay_oauth_application_external_reference_codes;
+
+  beforeEach(() => {
+    com_liferay_lxc_dxp_maindomain_env = process.env.COM_LIFERAY_LXC_DXP_MAINDOMAIN;
+    com_liferay_lxc_dxp_main_domain_env = process.env.COM_LIFERAY_LXC_DXP_MAIN_DOMAIN;
+    liferay_oauth_application_external_reference_codes = process.env.LIFERAY_OAUTH_APPLICATION_EXTERNAL_REFERENCE_CODES;
+  });
+
+  afterEach(() => {
+    process.env.COM_LIFERAY_LXC_DXP_MAINDOMAIN = com_liferay_lxc_dxp_maindomain_env;
+    process.env.COM_LIFERAY_LXC_DXP_MAIN_DOMAIN = com_liferay_lxc_dxp_main_domain_env;
+    process.env.LIFERAY_OAUTH_APPLICATION_EXTERNAL_REFERENCE_CODES = liferay_oauth_application_external_reference_codes;
+    clearCache();
+  });
+
   it('should return main domain from both mainDomain or main.domain is specified', function () {
-    process.env.COM_LIFERAY_LXC_DXP_MAIN_DOMAIN = 'localhost:8080';
     process.env.COM_LIFERAY_LXC_DXP_MAINDOMAIN = 'localhost:8080';
-    
+    process.env.COM_LIFERAY_LXC_DXP_MAIN_DOMAIN = 'localhost:8080';
+
     assert.equal(
-      dxpConfig['com.liferay.lxc.dxp.main.domain'](),
+      dxpConfig['com.liferay.lxc.dxp.mainDomain'](),
       'localhost:8080'
     );
 
     assert.equal(
-      dxpConfig['com.liferay.lxc.dxp.mainDomain'](),
+      dxpConfig['com.liferay.lxc.dxp.main.domain'](),
       'localhost:8080'
     );
   });


### PR DESCRIPTION
- add support for main.domain which is future proof
- tried setting ERC env var to just one and it assumes a string[]
